### PR TITLE
Allow to configure task handler

### DIFF
--- a/services/backend/common/__init__.py
+++ b/services/backend/common/__init__.py
@@ -1,2 +1,1 @@
 from .emails import SendEmail, EmailParams  # noqa
-from .tasks import Task  # noqa

--- a/services/backend/common/emails.py
+++ b/services/backend/common/emails.py
@@ -1,6 +1,10 @@
+import importlib
 from dataclasses import dataclass, asdict
 
-from .tasks import Task
+from django.conf import settings
+
+module_name, package = settings.TASKS_BASE_HANDLER.rsplit(".", maxsplit=1)
+Task = getattr(importlib.import_module(module_name), package)
 
 
 @dataclass

--- a/services/backend/common/tasks.py
+++ b/services/backend/common/tasks.py
@@ -11,16 +11,23 @@ class Task:
         self.source = source
         self.event_bus_name = event_bus_name
 
+    def get_entries(self, data: dict):
+        return [
+            {
+                'Time': datetime.now(),
+                'Source': self.source,
+                'DetailType': self.name,
+                'Detail': json.dumps({"type": self.name, **data}),
+                'EventBusName': self.event_bus_name,
+            },
+        ]
+
     def apply(self, data: dict):
         client = boto3.client('events', endpoint_url=settings.AWS_EVENTS_URL)
-        client.put_events(
-            Entries=[
-                {
-                    'Time': datetime.now(),
-                    'Source': self.source,
-                    'DetailType': self.name,
-                    'Detail': json.dumps({"type": self.name, **data}),
-                    'EventBusName': self.event_bus_name,
-                },
-            ]
-        )
+        client.put_events(Entries=self.get_entries(data))
+
+
+class TaskPrinter(Task):
+    def apply(self, data: dict):
+        entries = self.get_entries(data)
+        print(f"Put events: {entries=}")

--- a/services/backend/restauth/settings.py
+++ b/services/backend/restauth/settings.py
@@ -154,3 +154,5 @@ USER_NOTIFICATION_IMPL = "restauth.notifications.stdout"
 WORKERS_EVENT_BUS_NAME = env("WORKERS_EVENT_BUS_NAME", default=None)
 
 AWS_EVENTS_URL = env("AWS_EVENTS_URL", default=None)
+
+TASKS_BASE_HANDLER = env("TASKS_BASE_HANDLER", default="common.tasks.Task")


### PR DESCRIPTION
Previously, every task was sent as AWS event, which caused error for
local environment setup.

Now, there is possibility to set different handler, e.g. one that prints
every task to stdout and nothing more.