### PR TITLE
Unpack send-email event details

### DIFF
--- a/services/workers/emails/handlers.py
+++ b/services/workers/emails/handlers.py
@@ -10,4 +10,4 @@ logger.setLevel(logging.INFO)
 def send_email(event, context):
     logger.info(json.dumps(event, indent=2))
 
-    sender.send_email(data=event)
+    sender.send_email(data=event.get("detail") or event)

--- a/services/workers/emails/handlers.py
+++ b/services/workers/emails/handlers.py
@@ -10,4 +10,4 @@ logger.setLevel(logging.INFO)
 def send_email(event, context):
     logger.info(json.dumps(event, indent=2))
 
-    sender.send_email(data=event.get("detail") or event)
+    sender.send_email(data=event.get("detail", event))


### PR DESCRIPTION
SendEmail lambda function has different event structure on localstack and dev, which makes it crash

* Localstack
```
[INFO]	2020-08-03T08:38:37.1Z	f8b3f44c-221f-12fb-16ec-8c3153aabd5b	{
   "type": "WelcomeEmail",
   "to": "fwolwowicz@example4.com",
   "name": "Filip",
}
```

* Dev
```
[INFO]	2020-07-31T14:17:29.903Z	948a62b7-b762-446b-b1b0-8fd75b138e02	
{
    "version": "0",
    "id": "eff45b72-a0f1-8571-5c69-d2cc813feb5f",
    "detail-type": "WelcomeEmail",
    "source": "backend.email",
    "account": "946438046401",
    "time": "2020-07-31T14:17:28Z",
    "region": "eu-west-1",
    "resources": [],
    "detail": {
        "type": "WelcomeEmail",
        "to": "fwolwowicz@example4.com",
        "name": "Filip"
    }
}
```