### PR TITLE
Fix aws-vault InvalidClientTokenId

### DIFF
--- a/base.mk
+++ b/base.mk
@@ -24,7 +24,7 @@ endef
 export TOOLS_ENABLED := $(call GetFromCfg,toolsConfig.enabled)
 
 AWS_VAULT_PROFILE ?= $(call GetFromCfg,aws.profile)
-AWS_VAULT = aws-vault exec $(AWS_VAULT_PROFILE) --
+AWS_VAULT = aws-vault exec $(AWS_VAULT_PROFILE) --no-session --
 
 ifeq ($(CI),true)
 	VERSION := $(shell cat $(BASE_DIR)/VERSION)


### PR DESCRIPTION
**Problem**

Rencently I'm trying to run

```
make deploy-global-infra
```

And it sadly failed in creation of IAM User.

```
11:38:11 PM | CREATE_FAILED        | AWS::IAM::User              | GlobalResources/CodeCommit/CodeRepoUser
The security token included in the request is invalid (Service: AmazonIdentityManagement; Status Code: 403; Error Code: InvalidClientTokenId; Request ID: XXXXX-XXXXXX-XXXXXXX; Proxy: null) The security token included in the request is invalid (Service: AmazonIdentityManagement; Status Code: 403; Error Code: InvalidClientTokenId; Request ID: XXXXX-XXXXXX-XXXXXXX; Proxy: null
```

Searching the problem I find [this issue in aws-vault](https://github.com/99designs/aws-vault/issues/702). So, when using temporary credentials you are restricted from using some STS and IAM APIs. You may need to avoid the temporary session by using `--no-session`.

**Solution**

Finally, the solution is add parameter `--no-session` in AWS_VAULT var.